### PR TITLE
convert the result of evaluate to list from generator or map

### DIFF
--- a/shublang/shublang.py
+++ b/shublang/shublang.py
@@ -7,6 +7,7 @@ import builtins
 import math
 import json
 import logging
+import types
 
 """
 Conventions
@@ -169,4 +170,7 @@ def evaluate(expression, data):
     # TODO use StatementParser.is_safe before evaluating code.
     # if StatementParser.is_safe(expression):
     # FIXME DANGEROUS!! Only for POC. This needs to be reimplemented using Lark.
-    return eval(f'data|{expression}')
+    data = eval(f'data|{expression}')
+    if isinstance(data, (types.GeneratorType, builtins.map)):
+        data = list(data)
+    return data


### PR DESCRIPTION
It converts the result of `evaluate` to a list if it's a `generator` or `map`
Example before the fix
```
>>> shublang.evaluate('int', ['3'])
<map at 0x1086fd7b8>
```

after the fix
```
>>> shublang.evaluate('int', ['3'])
[3]
```