### PR TITLE
add tox config to test Python 3.5 to 3.8

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,42 +1,37 @@
-# Python CircleCI 2.0 configuration file
-#
-# Check https://circleci.com/docs/2.0/language-python/ for more details
-#
 version: 2
 jobs:
-  toxify:
+  python3.5:
     docker:
-      - image: themattrix/tox
+      - image: python:3.5
     steps:
       - checkout
-      - run:
-          name: Run tests in supported Python versions
-          command: |
-            pip install tox tox-pyenv
-            pyenv local 3.5.3 3.6.0 3.7.0 3.8.0
-            tox
-  build:
+      - run: |
+          pip install tox
+          tox
+  python3.6:
     docker:
-      - image: circleci/python:3.6.1
+      - image: python:3.6
     steps:
       - checkout
-      # Download and cache dependencies
-      - restore_cache:
-          keys:
-            - v1-dependencies-{{ checksum "requirements.txt" }}
-            # fallback to using the latest cache if no exact match is found
-            - v1-dependencies-
-      - run:
-          name: install dependencies
-          command: |
-            python3 -m venv venv
-            . venv/bin/activate
-            pip install -r requirements.txt
-            pip install -r requirements-dev.txt
-      - save_cache:
-          paths:
-            - ./venv
-          key: v1-dependencies-{{ checksum "requirements.txt" }}
+      - run: |
+          pip install tox
+          tox
+  python3.7:
+    docker:
+      - image: python:3.7
+    steps:
+      - checkout
+      - run: |
+          pip install tox
+          tox
+  python3.8:
+    docker:
+      - image: python:3.8
+    steps:
+      - checkout
+      - run: |
+          pip install tox
+          tox
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,6 @@ workflows:
 
   shublang:
     jobs:
-      - python3.5
       - python3.6
       - python3.7
       - python3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,5 +38,7 @@ workflows:
 
   shublang:
     jobs:
-      - toxify
-      - build
+      - python3.5
+      - python3.6
+      - python3.7
+      - python3.8

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,17 @@
 #
 version: 2
 jobs:
+  toxify:
+    docker:
+      - image: themattrix/tox
+    steps:
+      - checkout
+      - run:
+          name: Run tests in supported Python versions
+          command: |
+            pip install tox tox-pyenv
+            pyenv local 3.5.3 3.6.0 3.7.0 3.8.0
+            tox
   build:
     docker:
       - image: circleci/python:3.6.1
@@ -26,9 +37,11 @@ jobs:
           paths:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
-      # Run tests
-      - run:
-          name: run tests
-          command: |
-            . venv/bin/activate
-            pip install tox && tox
+
+workflows:
+  version: 2
+
+  shublang:
+    jobs:
+      - toxify
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,13 +1,5 @@
 version: 2
 jobs:
-  python3.5:
-    docker:
-      - image: python:3.5
-    steps:
-      - checkout
-      - run: |
-          pip install tox
-          tox
   python3.6:
     docker:
       - image: python:3.6

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,4 +31,4 @@ jobs:
           name: run tests
           command: |
             . venv/bin/activate
-            py.test
+            pip install tox && tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,3 +19,4 @@ six==1.12.0
 w3lib==1.21.0
 wcwidth==0.1.7
 zipp==0.6.0
+tox

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
     install_requires=[
         'pipe >= 1.5.0',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+envlist = py35, py36, py37, py38
+skip_missing_interpreters = True
+
+[testenv]
+commands = pytest tests/
+deps =
+    pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,5 @@
 [tox]
-envlist = py35, py36, py37, py38
-skip_missing_interpreters = True
+envlist = py
 
 [testenv]
 commands = pytest tests/


### PR DESCRIPTION
@akshayphilar I'm adding some tox configs since we need to ensure that the new functionalities we will be implementing in https://github.com/scrapinghub/shublang/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22 correctly runs across different Python 3 versions.

@jsargiot, I'm quite unfamiliar with **CircleCI** as SH uses **Travis CI** in majority of its repos. Could you review if I'm invoking `tox` correctly?


For **Travis CI**, we usually configure it via https://github.com/scrapy/itemloaders/blob/master/.travis.yml#L8-L23 which results in https://travis-ci.com/github/scrapy/itemloaders/builds/178576103, testing across the declared Python environments.

**EDIT**: Looks like the new tox config correctly runs in **Circle CI** as can be seen in this [build](https://app.circleci.com/pipelines/github/scrapinghub/shublang/26/workflows/d688f24b-97a7-442c-b3d3-35bd7dc7adbf/jobs/26). However, it would seem that some of the Python envs are not setup yet in it.

![image](https://user-images.githubusercontent.com/3449761/89492848-2ff09500-d7e5-11ea-85e3-7f6e0738df47.png)


Thanks!