### PR TITLE
Add new 'replace' functionality

### DIFF
--- a/shublang/shublang.py
+++ b/shublang/shublang.py
@@ -29,16 +29,31 @@ Alternatively, should this be handled in the traversal code?
 
 logging.basicConfig(format='%(levelname)s:%(message)s', level=logging.DEBUG)
 
+
 @Pipe
 def sub(iterable, pattern, repl=None):
-    if not repl:
-        repl = ""
+    """Replaces a substring with another substring using regular expressions.
+
+    :param iterable: collection of data to transform
+    :type iterable: list
+
+    :param pattern: regular expression to match and be replaced
+    :type pattern: string
+
+    :param repl: (optional) the replacement substring
+    :type rep: string
+    """
+
+    repl = repl or ""
     return (re.sub(pattern, repl, x) for x in iterable)
 
 
 @Pipe
 def replace(iterable, old, new, count=None):
     """Replaces a substring with another substring.
+
+    :param iterable: collection of data to transform
+    :type iterable: list
 
     :param old: substring to be replaced
     :type old: string

--- a/shublang/shublang.py
+++ b/shublang/shublang.py
@@ -37,6 +37,29 @@ def sub(iterable, pattern, repl=None):
 
 
 @Pipe
+def replace(iterable, old, new, count=None):
+    """Replaces a substring with another substring.
+
+    :param old: substring to be replaced
+    :type old: string
+
+    :param new: the replacement substring
+    :type new: string
+
+    :param count: (optional) The first n substring occurrences to be replaced
+    :type count: int
+
+    NOTE: This doesn't support regular expressions which makes it safer and
+    easier. If you need regular expressions, make use :func:`sub` which supports
+    it.
+    """
+
+    if count:
+        return (x.replace(old, new, count) for x in iterable)
+    return (x.replace(old, new) for x in iterable)
+
+
+@Pipe
 def encode(iterable, encoding, errors='ignore'):
     return (x.encode(encoding, errors=errors) for x in iterable)
 

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -3,13 +3,30 @@
 import pytest
 from shublang import evaluate
 
-def test_sub():
-    text = "Python,Haskell,Scala,Rust"
-    assert evaluate('sub(",", " ")', data=[text]) == ["Python Haskell Scala Rust"]
 
-def test_sub_2():
-    text = "Python,Haskell,Scala,Rust"
-    assert evaluate('sub(",")', data=[text]) == ["PythonHaskellScalaRust"]
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            ['sub(",", " ")', ['Python,Haskell,Scala,Rust']],
+            ['Python Haskell Scala Rust']
+        ),
+
+        # Optional 'repl' param should work.
+        (
+            ['sub(",")', ['Python,Haskell,Scala,Rust']],
+            ['PythonHaskellScalaRust']
+        ),
+
+        # Regular Expressions should work.
+        (
+            ['sub("b{2}(?:\s+)", "xx ")', ['b bb          bbb']],
+            ['b xx bbb']
+        ),
+    ]
+)
+def test_sub(test_input, expected):
+    assert evaluate(*test_input) == expected
 
 
 @pytest.mark.parametrize(
@@ -20,7 +37,7 @@ def test_sub_2():
             ['Pretty dope']
         ),
 
-        # Optional count param should work on the first n patterns encountered.
+        # Optional 'count' param should work on the first n patterns encountered.
         (
             ['replace("bb", "xx", 2)', ['bbb bbb bbb']],
             ['xxb xxb bbb']

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -1,5 +1,6 @@
 # TODO add tests for functions
 
+import pytest
 from shublang import evaluate
 
 def test_sub():
@@ -9,6 +10,32 @@ def test_sub():
 def test_sub_2():
     text = "Python,Haskell,Scala,Rust"
     assert evaluate('sub(",")', data=[text]) == ["PythonHaskellScalaRust"]
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
+            ['replace("cool", "dope")', ['Pretty cool']],
+            ['Pretty dope']
+        ),
+
+        # Optional count param should work on the first n patterns encountered.
+        (
+            ['replace("bb", "xx", 2)', ['bbb bbb bbb']],
+            ['xxb xxb bbb']
+        ),
+
+        # Regular expressions won't work on `replace`.
+        (
+            ['replace("t+", "xx")', ['Regex Attempt']],
+            ['Regex Attempt']
+        ),
+    ]
+)
+def test_replace(test_input, expected):
+    assert evaluate(*test_input) == expected
+
 
 def test_encode():
     text = "ἀἐἠἰὀὐὠὰᾀᾐ"


### PR DESCRIPTION
Implements #12 

Some notes:

- I've updated `sub` alongside this do differentiate it more clearly with `replace` and avoid some confusion.