### PR TITLE
add regression tests

### DIFF
--- a/shublang/shublang.py
+++ b/shublang/shublang.py
@@ -150,6 +150,7 @@ def sanitize(iterable):
     # TODO change name and add other options
 
     iterable = (x.strip() for x in iterable)
+    iterable = (x for x in iterable if x)
     iterable = (re.sub(r'[\n\t\r\s]+', ' ', x) for x in iterable)
     iterable = (x.encode('ascii', errors='ignore').decode('ascii') for x in iterable)
     iterable = (replace_entities(x) for x in iterable)

--- a/tests/test_regression.py
+++ b/tests/test_regression.py
@@ -1,0 +1,14 @@
+"""This serves as a test bed for using shublang in complex real-world scenarios.
+"""
+
+from shublang import evaluate
+
+
+def test_get_non_empty_price():
+    data = ['  \r\t   \n   ', '\n', '\n', '  \tprice: $123,823.00 \n', ' ']
+    expression = 'sanitize | sub("[\$,]", "")'
+
+    data = evaluate(expression, data)
+    assert data == ['price: 123823.00']
+
+    assert evaluate('re_search("(\d+\.\d{2})") | first | float | first', data) == 123823.00


### PR DESCRIPTION
This test need not be merged into master but instead provides the necessary stimuli to see some pain points in `shublang`'s usage.

In particular we can see that:

1. The current `sanitize` functionality returns empty strings in its iterable. This presents the need to update it to prune out the empty strings, otherwise it would evaluate our test example as `['', '', '', 'price: $123,823.00', '']`

2. We need to do a **double** `first`, since the **1st** one transforms `[('123823.00',)]` into `('123823.00',)` and the **2nd** one transforms `(123823.00,)` into `123823.00`.

3. The `float` functionality needs to be in between the **double** `first` since it only works on iterables.

As we can see, we need to jump on a lot of hoops just to properly extract this type of data.

Ideally, we should have a way to extract the data in a very concise manner like: `re_search("(\d+\.\d{2}) | first_match`