### PR TITLE
add new 'str' functionality

### DIFF
--- a/shublang/shublang.py
+++ b/shublang/shublang.py
@@ -232,6 +232,10 @@ def bool(iterable):
     return (builtins.bool(x) for x in iterable)
 
 @Pipe
+def str(iterable):
+    return (builtins.str(x) for x in iterable)
+
+@Pipe
 def float(iterable):
     return (builtins.float(x) for x in iterable)
 
@@ -294,7 +298,7 @@ def date_format(iterable, fmt):
 
 @Pipe
 def extract_price(iterable):
-    return (str(Price.fromstring(item).amount) for item in iterable)
+    return (builtins.str(Price.fromstring(item).amount) for item in iterable)
 
 @Pipe
 def extract_currency(iterable):

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -8,6 +8,27 @@ from shublang import evaluate
     "test_input,expected",
     [
         (
+            ['str', [1, 2, 3]],
+            ['1', '2', '3']
+        ),
+        (
+            ['str', [1.1, 2.2, 3.3]],
+            ['1.1', '2.2', '3.3']
+        ),
+        (
+            ['str', ['1', '2', '3']],
+            ['1', '2', '3']
+        ),
+    ]
+)
+def test_str(test_input, expected):
+    assert evaluate(*test_input) == expected
+
+
+@pytest.mark.parametrize(
+    "test_input,expected",
+    [
+        (
             ['sub(",", " ")', ['Python,Haskell,Scala,Rust']],
             ['Python Haskell Scala Rust']
         ),


### PR DESCRIPTION
As discussed at #53, it implements the `str` functionality. It also modifies the `extract_price` function to use `builtins.str` instead of `str`, in order to avoid conflicts evaluating the expressions of price extraction.