### PR TITLE
Make unidecode optional in sanitize methods

### DIFF
--- a/shublang/shublang.py
+++ b/shublang/shublang.py
@@ -187,13 +187,10 @@ def split(iterable, sep, maxsplit=-1):
 
 
 @Pipe
-def sanitize(iterable, ascii_safe=False):
+def sanitize(iterable):
     # TODO change name and add other options
-
     iterable = (x.strip() for x in iterable)
     iterable = (re.sub(r'[\n\t\r\s]+', ' ', x) for x in iterable)
-    if ascii_safe:
-        iterable = (unidecode(x) for x in iterable)
     iterable = (replace_entities(x) for x in iterable)
     iterable = (remove_tags(x) for x in iterable)
     return iterable
@@ -386,6 +383,10 @@ def urlparse(iterable):
     parsed_iterable = ({"scheme": it.scheme, "netloc": it.netloc, "path": it.path,
                         "params": it.params, "query": it.query, "fragment": it.fragment} for it in parsed_iterable)
     return parsed_iterable
+
+@Pipe
+def ascii_safe(iterable):
+    return (unidecode(x) for x in iterable)
 
 filter = where
 map = select

--- a/shublang/shublang.py
+++ b/shublang/shublang.py
@@ -40,7 +40,7 @@ def map_value(iterable, rules_dict):
     :param iterable: collection of data to transform
     :type iterable: list
 
-    :param rules_dict: rules dictionary where the key should be the 
+    :param rules_dict: rules dictionary where the key should be the
     exactly text to look for and the value should be the desired output
     :type rules_dict: dict
 
@@ -187,12 +187,13 @@ def split(iterable, sep, maxsplit=-1):
 
 
 @Pipe
-def sanitize(iterable):
+def sanitize(iterable, ascii_safe=False):
     # TODO change name and add other options
 
     iterable = (x.strip() for x in iterable)
     iterable = (re.sub(r'[\n\t\r\s]+', ' ', x) for x in iterable)
-    iterable = (unidecode(x) for x in iterable)
+    if ascii_safe:
+        iterable = (unidecode(x) for x in iterable)
     iterable = (replace_entities(x) for x in iterable)
     iterable = (remove_tags(x) for x in iterable)
     return iterable

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -10,7 +10,7 @@ from shublang import evaluate
         # if a mapping is not found, return the value itself
         (
             [
-                'map_value({"This is foo": "foo", "This is bar": "bar"})', 
+                'map_value({"This is foo": "foo", "This is bar": "bar"})',
                 ["This is foo", "This is not bar"]
             ],
             ['foo', 'This is not bar']
@@ -19,7 +19,7 @@ from shublang import evaluate
         # usual mapping
         (
             [
-                'map_value({"1": "Available", "2": "Unavailable"})', 
+                'map_value({"1": "Available", "2": "Unavailable"})',
                 ['1', '2']
             ],
             ['Available', 'Unavailable']
@@ -28,7 +28,7 @@ from shublang import evaluate
         # map string to number
         (
             [
-                'map_value({"InStock": 1, "OutOfStock": 2})', 
+                'map_value({"InStock": 1, "OutOfStock": 2})',
                 ['OutOfStock', 'InStock']
             ],
             [2, 1]
@@ -37,7 +37,7 @@ from shublang import evaluate
         # map number to string
         (
             [
-                'map_value({0: "Online", 1: "Offline"})', 
+                'map_value({0: "Online", 1: "Offline"})',
                 [0, 1]
             ],
             ['Online', 'Offline']
@@ -268,7 +268,10 @@ def test_sanitize():
 
 def test_sanitize_1():
     text = [u"Checking unicode ko\u017eu\u0161\u010dek \t\t\t\t"]
-    assert evaluate("sanitize", data=text) == ["Checking unicode kozuscek"]
+    assert evaluate("sanitize(ascii_safe=True)", data=text) == ["Checking unicode kozuscek"]
+
+    text = [u"Checking unicode ko\u017eu\u0161\u010dek \t\t\t\t"]
+    assert evaluate("sanitize", data=text) == ["Checking unicode kožušček"]
 
 def test_xpath_getall():
     html = '<div><li class="results"><ul>Skoda</ul><ul>Vauxhall</ul><ul>Peugot</ul></li></div>'

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -268,10 +268,13 @@ def test_sanitize():
 
 def test_sanitize_1():
     text = [u"Checking unicode ko\u017eu\u0161\u010dek \t\t\t\t"]
-    assert evaluate("sanitize(ascii_safe=True)", data=text) == ["Checking unicode kozuscek"]
-
-    text = [u"Checking unicode ko\u017eu\u0161\u010dek \t\t\t\t"]
     assert evaluate("sanitize", data=text) == ["Checking unicode kožušček"]
+
+
+def test_ascii_safe():
+    text = [u"Checking unicode ko\u017eu\u0161\u010dek"]
+    assert evaluate("ascii_safe", data=text) == ["Checking unicode kozuscek"]
+
 
 def test_xpath_getall():
     html = '<div><li class="results"><ul>Skoda</ul><ul>Vauxhall</ul><ul>Peugot</ul></li></div>'


### PR DESCRIPTION
Allow to sanitize text from non English websites without losing data.

This is not **backward compatibility** as I believe this should be the default behavior in most cases.